### PR TITLE
11.5 updates.

### DIFF
--- a/bin/README.md
+++ b/bin/README.md
@@ -4,6 +4,6 @@ The google protobuf repo provides precompiled binaries on their [release](https:
 
 You can also download the protobuf source code and build the `protoc.exe` compiler following the instructions here: https://github.com/protocolbuffers/protobuf/tree/master/cmake#readme
 
-For 11.2 Final, we require protobuf compiler version 3.21.12.
+For 11.5 Final, we require protobuf compiler version 25.5.
 
 Once you have generated the `protoc.exe` compiler, you can place it here in this `bin` folder and execute `build.ps1` from the repository root directory.

--- a/build.ps1
+++ b/build.ps1
@@ -1,5 +1,5 @@
 
-<# Copyright 2023 Esri
+<# Copyright 2025 Esri
  #
  # Licensed under the Apache License Version 2.0 (the "License");
  # you may not use this file except in compliance with the License.
@@ -15,7 +15,7 @@
  #>
  
 $compiler_path = "bin\protoc.exe"
-$runtime_ver = "3.21.12"
+$runtime_ver = "25.5"
 $proto_folder = Get-Item ".\proto"
 
 # C++
@@ -43,21 +43,11 @@ function Compare-Versions($lhs,$rhs)
 	if ($lhs.Contains("-")) { $lhs = $lhs.Split('-')[0] }
 	if ($rhs.Contains("-")) { $rhs = $rhs.Split('-')[0] }
 
-	$lhs_major = [int]$lhs.Split('.')[0]
-	$lhs_minor = [int]$lhs.Split('.')[1]
-	$lhs_patch = [int]$lhs.Split('.')[2]
+	$lhs_minor = [int]$lhs.Split('.')[0]
+	$lhs_patch = [int]$lhs.Split('.')[1]
 
-	$rhs_major = [int]$rhs.Split('.')[0]
-	$rhs_minor = [int]$rhs.Split('.')[1]
-	$rhs_patch = [int]$rhs.Split('.')[2]
-
-	if ($lhs_major -gt $rhs_major) {
-		return -3
-	}
-
-	if ($lhs_major -lt $rhs_major) {
-		return 3
-	}
+	$rhs_minor = [int]$rhs.Split('.')[0]
+	$rhs_patch = [int]$rhs.Split('.')[1]
 
 	if ($lhs_minor -gt $rhs_minor) {
 		return -2
@@ -157,11 +147,6 @@ function Validate-Protoc-Version()
     {
         throw ("CRITICAL ERROR! Protocol Buffer compiler version ("+ $protoc_ver +") is higher than server runtime version ("+ $runtime_ver + "). Please update protobuf compiler version!")
     }
-
-
-    if (($ver_comp -eq -3) -or ($ver_comp -eq 3)) {
-		throw ("CRITICAL ERROR! Protocol Buffer compiler version ("+ $protoc_ver +") has a different major version than the server runtime ("+ $runtime_ver +")")
-	}
 }
 
 function Invoke-Compiler($includes, $out_path_arg, $out_path, $protoFiles)

--- a/proto/esriPBuffer/graph/ApplyEditsResponse.proto
+++ b/proto/esriPBuffer/graph/ApplyEditsResponse.proto
@@ -91,4 +91,13 @@ message GraphApplyEditsResult {
 
   // Deleted provenance records due to the deletion of their source entity, relationship, or property-value.
   CascadingProvenanceDeletes cascading_provenance_delete_results = 10;
+
+  // portal username and the timestamp when the operation was performed
+  ApplyEditsMetadata apply_edits_metadata = 11;
+}
+
+message ApplyEditsMetadata {
+  string user_name = 1;
+  // UTC UNIX timestamp in milliseconds since epoch.
+  uint64 timestamp = 2;
 }

--- a/proto/esriPBuffer/graph/AsyncResultResponse.proto
+++ b/proto/esriPBuffer/graph/AsyncResultResponse.proto
@@ -30,6 +30,7 @@ message AsyncResultResponse {
 	uint64 submission_time = 2;
 	// end time of the async operation. UTC UNIX epoch in milliseconds.
 	uint64 completion_time = 3;
+
 	oneof operation_response {
 		SyncDataModelResponse sync_data_model_response = 4;
 	}

--- a/proto/esriPBuffer/graph/DataModelTypes.proto
+++ b/proto/esriPBuffer/graph/DataModelTypes.proto
@@ -168,11 +168,11 @@ message SetOfNamedTypes {
 
 // A relationship exclusion rule consists of a set of origin entity types, a
 // set of relationship types, and a set of destination entity types. A
-// relationship instance matches the pattern specified by the rule
+// relationship matches the pattern specified by the rule
 // if the origin entity's type is contained in the set of origin entity types,
 // the relationship's type is contained in the set of relationship types, and
 // the destination entity's type is contained in the set of destination entity
-// types. A relationship exclusion rule mandates that a relationship instance
+// types. A relationship exclusion rule mandates that a relationship
 // must not match the pattern specified by the rule.
 message RelationshipExclusionRule {
 	SetOfNamedTypes origin_entity_types = 1;
@@ -193,8 +193,8 @@ enum ConstraintRuleRole {
 	RelationshipExclusion_NoProvenanceDestination = 4;
 }
 
-// When enabled, constraint rules are applied to entity or relationship
-// instances during ApplyEdits.
+// When enabled, constraint rules are applied to entities or relationships
+// during ApplyEdits.
 message ConstraintRule {
 	string name = 1;
 	string alias = 2;


### PR DESCRIPTION
## Knowledge-PBF v11.5.0 Release Notes
May 2025
## Upgrades
### Protobuf Compiler Upgrade
 - The protobuf compiler used to generate classes has been moved to [`25.5`](https://github.com/protocolbuffers/protobuf/releases/tag/v25.5).  
 - Instructions to compile proto files: https://github.com/Esri/knowledge-pbf/tree/master/bin#compiling-protobuf-definitions
## New Features
### Apply Edits Response
 - The `GraphApplyEditsResult` now includes a new parameter, `apply_edits_metadata` that returns metadata about the apply edits operation. Namely, the username and timestamp of the applyEdits operation primarily used by editor tracking.
 